### PR TITLE
fix(tests): Agregar helper get_test_company() para consistencia en tests

### DIFF
--- a/barriofarma_app/barriofarma_app/custom_tests/test_purchase_receipt_expiry_threshold_ddd.py
+++ b/barriofarma_app/barriofarma_app/custom_tests/test_purchase_receipt_expiry_threshold_ddd.py
@@ -18,6 +18,7 @@ from barriofarma_app.barriofarma_app.test_setup import (
     create_test_warehouse,
     create_test_purchase_order,
     create_test_batch,
+    get_test_company,
 )
 
 
@@ -104,7 +105,7 @@ class TestPurchaseReceiptExpiryThresholdDDD(unittest.TestCase):
         Invariante DDD: Items con vencimiento bajo umbral quedan automáticamente en Cuarentena
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         # Crear Item Group con umbral de 6 meses
         item_group = frappe.get_doc({
@@ -181,7 +182,7 @@ class TestPurchaseReceiptExpiryThresholdDDD(unittest.TestCase):
         Invariante DDD: Si un item ya está rechazado manualmente, no se sobrescribe a Cuarentena
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         item = create_test_item(
             item_code=f"TEST-ITEM-{frappe.generate_hash(length=6)}",
@@ -244,7 +245,7 @@ class TestPurchaseReceiptExpiryThresholdDDD(unittest.TestCase):
         Invariante DDD: El umbral configurado en Item Group tiene prioridad sobre Company
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         # Configurar Company con umbral de 12 meses
         frappe.db.set_value("Company", company_name, "custom_minimum_expiry_months", 12)

--- a/barriofarma_app/barriofarma_app/test_setup.py
+++ b/barriofarma_app/barriofarma_app/test_setup.py
@@ -66,6 +66,25 @@ def get_or_create_root_territory():
     return territory_name
 
 
+def get_test_company():
+    """
+    Obtiene la company correcta para tests (siempre Barriofarma si existe, con CLP)
+    
+    Returns:
+        str: Nombre de la company (prioriza Barriofarma con CLP)
+    """
+    # Primero intentar usar Barriofarma (company real con CLP)
+    if frappe.db.exists("Company", "Barriofarma"):
+        return "Barriofarma"
+    else:
+        # Fallback: cualquier company con CLP
+        company = frappe.db.get_value("Company", {"default_currency": "CLP"}, "name")
+        if company:
+            return company
+        # Último recurso: cualquier company disponible
+        return frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+
+
 def create_test_customer(customer_name, customer_type="Individual", **kwargs):
     """
     Función auxiliar para crear Customer de prueba

--- a/barriofarma_app/barriofarma_app/tests/test_bf008_umbral_vencimiento.py
+++ b/barriofarma_app/barriofarma_app/tests/test_bf008_umbral_vencimiento.py
@@ -18,6 +18,7 @@ from barriofarma_app.barriofarma_app.test_setup import (
     create_test_warehouse,
     create_test_purchase_order,
     create_test_batch,
+    get_test_company,
 )
 
 
@@ -109,7 +110,7 @@ class TestBF008UmbralVencimiento(unittest.TestCase):
           Then el sublote queda automáticamente en Cuarentena
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         # Given: Item Group con umbral de 6 meses
         item_group = frappe.get_doc({
@@ -189,7 +190,7 @@ class TestBF008UmbralVencimiento(unittest.TestCase):
           Then el sublote queda Aceptado
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         # Given: Item Group con umbral de 6 meses
         item_group = frappe.get_doc({
@@ -274,7 +275,7 @@ class TestBF008UmbralVencimiento(unittest.TestCase):
           Then el sublote corto queda en Cuarentena y el largo queda Aceptado
         """
         # Setup
-        company_name = frappe.db.get_value("Company", {"name": ("!=", "")}, "name")
+        company_name = get_test_company()
         
         # Given: Item Group con umbral de 6 meses
         item_group = frappe.get_doc({


### PR DESCRIPTION
## 🐛 Problema Resuelto

Los tests de `expiry_threshold_ddd` y `bf008_umbral_vencimiento` fallaban con error:
```
ValidationError: Incorrect value:Company must be equal to 'Barriofarma'
```

**Causa:** Los tests obtenían cualquier company disponible (`frappe.db.get_value("Company", {"name": ("!=", "")}, "name")`), mientras que `create_test_purchase_order()` siempre usa "Barriofarma" gracias al fix anterior. Esto causaba que el Purchase Receipt tuviera una company diferente a la del Purchase Order, fallando la validación de ERPNext.

## ✅ Solución Implementada

1. **Agregado helper `get_test_company()`** en `test_setup.py`:
   - Prioriza "Barriofarma" si existe (company real con CLP)
   - Fallback a cualquier company con CLP
   - Último recurso: cualquier company disponible
   - Misma lógica que `create_test_purchase_order()` para consistencia

2. **Actualizados tests para usar el helper**:
   - `test_purchase_receipt_expiry_threshold_ddd.py` (3 tests corregidos)
   - `test_bf008_umbral_vencimiento.py` (3 tests corregidos)

## 📊 Resultados

**Antes:** 65/71 tests pasando (6 fallando)  
**Después:** 71/71 tests pasando (100%) ✅

### Tests Corregidos:
- ✅ `test_invariante_umbral_vencimiento_cuarentena`
- ✅ `test_invariante_umbral_vencimiento_no_sobrescribe_rechazo_manual`
- ✅ `test_invariante_umbral_vencimiento_respetado_por_item_group`
- ✅ `test_e2e_recepcion_sublote_bajo_umbral_cuarentena`
- ✅ `test_e2e_recepcion_sublote_sobre_umbral_aceptado`
- ✅ `test_e2e_recepcion_multiple_sublotes_umbral_diferente`

## 🧹 Limpieza de Datos

Ejecutado script de limpieza:
- ✅ 1 company de prueba eliminada (`_Test Company`)
- ✅ Base de datos limpia

## 📝 Archivos Modificados

- `barriofarma_app/barriofarma_app/test_setup.py` (+15 líneas)
- `barriofarma_app/barriofarma_app/custom_tests/test_purchase_receipt_expiry_threshold_ddd.py` (+1 import, 3 reemplazos)
- `barriofarma_app/barriofarma_app/tests/test_bf008_umbral_vencimiento.py` (+1 import, 3 reemplazos)

## ✅ Checklist

- [x] Tests pasando (71/71)
- [x] Script de limpieza ejecutado
- [x] Código sigue convenciones del proyecto
- [x] Helper reutilizable para futuros tests