### PR TITLE
feat(catalogo): add terrain sales order API and permissions

### DIFF
--- a/barriofarma_app/barriofarma_app/api/catalogo_terreno.py
+++ b/barriofarma_app/barriofarma_app/api/catalogo_terreno.py
@@ -1,0 +1,345 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Barrio Farma and Contributors
+# See license.txt
+
+"""API catalogo + carrito para vendedores en terreno (issue whiteboard #75)."""
+
+from __future__ import annotations
+
+import logging
+
+import frappe
+from frappe import _
+from frappe.utils import add_days, cint, flt, nowdate, parse_json
+
+from erpnext.accounts.party import get_party_details
+
+from barriofarma_app.barriofarma_app.test_setup import get_test_company
+
+logger = logging.getLogger(__name__)
+
+ROLE_VENDEDOR_TERRENO = "Vendedor Terreno"
+DEFAULT_DELIVERY_DAYS = 7
+POST_LOGIN_CATALOGO_PATH = "/inicio/catalogo"
+POST_LOGIN_DESK_PATH = "/app"
+
+
+def _ensure_catalogo_access():
+	if frappe.session.user in (None, "Guest"):
+		frappe.throw(_("Inicie sesion para continuar"), frappe.AuthenticationError)
+
+	roles = set(frappe.get_roles())
+	if ROLE_VENDEDOR_TERRENO not in roles and "Administrator" not in roles:
+		frappe.throw(
+			_("No tiene permiso para acceder al catalogo de terreno"),
+			frappe.PermissionError,
+		)
+
+
+def _get_default_company() -> str:
+	company = frappe.defaults.get_user_default("Company") or frappe.db.get_single_value(
+		"Global Defaults", "default_company"
+	)
+	if company:
+		return company
+	try:
+		return get_test_company()
+	except Exception:
+		company = frappe.db.get_value("Company", {}, "name")
+		if not company:
+			frappe.throw(_("No hay Company configurada en el sitio"))
+		return company
+
+
+def _get_default_warehouse(company: str) -> str | None:
+	"""Almacen por defecto para lineas de Sales Order (items de stock exigen warehouse)."""
+	warehouse = frappe.db.get_value(
+		"Warehouse",
+		{"company": company, "is_group": 0, "disabled": 0},
+		"name",
+		order_by="creation asc",
+	)
+	if warehouse:
+		return warehouse
+
+	global_wh = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+	if global_wh and frappe.db.get_value("Warehouse", global_wh, "company") == company:
+		return global_wh
+
+	return None
+
+
+def _get_sales_person_for_user(user: str | None = None) -> str | None:
+	"""Resolve Sales Person via Employee.user_id (ERPNext v16 has no direct User link on Sales Person)."""
+	user = user or frappe.session.user
+	employee = frappe.db.get_value("Employee", {"user_id": user, "status": "Active"}, "name")
+	if not employee:
+		logger.warning(
+			"catalogo_terreno: usuario %s sin Employee vinculado; sales_team omitido",
+			user,
+		)
+		return None
+
+	sales_person = frappe.db.get_value(
+		"Sales Person",
+		{"employee": employee, "enabled": 1},
+		"name",
+	)
+	if not sales_person:
+		logger.warning(
+			"catalogo_terreno: Employee %s sin Sales Person habilitado; sales_team omitido",
+			employee,
+		)
+	return sales_person
+
+
+def _list_catalog_items_impl(
+	search_term=None,
+	item_group=None,
+	price_list=None,
+	start=0,
+	page_length=20,
+):
+	if not price_list:
+		frappe.throw(_("price_list es obligatorio"))
+
+	filters = {"disabled": 0, "is_sales_item": 1}
+	if item_group:
+		filters["item_group"] = item_group
+
+	or_filters = None
+	if search_term and str(search_term).strip():
+		term = f"%{search_term.strip()}%"
+		or_filters = [["item_code", "like", term], ["item_name", "like", term]]
+
+	items = frappe.get_all(
+		"Item",
+		filters=filters,
+		or_filters=or_filters,
+		fields=[
+			"name as item_code",
+			"item_name",
+			"item_group",
+			"image",
+			"stock_uom as uom",
+			"custom_control_level",
+		],
+		limit_start=cint(start),
+		limit_page_length=cint(page_length),
+		order_by="item_name asc",
+	)
+
+	if not items:
+		return []
+
+	item_codes = [row["item_code"] for row in items]
+	price_rows = frappe.get_all(
+		"Item Price",
+		filters={"price_list": price_list, "item_code": ["in", item_codes]},
+		fields=["item_code", "price_list_rate"],
+	)
+	price_map = {row.item_code: flt(row.price_list_rate) for row in price_rows}
+
+	stock_rows = frappe.db.sql(
+		"""
+		SELECT item_code, SUM(actual_qty) AS stock_qty
+		FROM `tabBin`
+		WHERE item_code IN %(items)s
+		GROUP BY item_code
+		""",
+		{"items": item_codes},
+		as_dict=True,
+	)
+	stock_map = {row.item_code: max(0.0, flt(row.stock_qty)) for row in stock_rows}
+
+	result = []
+	for row in items:
+		code = row["item_code"]
+		if code not in price_map:
+			continue
+		result.append(
+			{
+				"item_code": code,
+				"item_name": row["item_name"],
+				"item_group": row["item_group"],
+				"image": row.get("image"),
+				"uom": row["uom"],
+				"rate": price_map[code],
+				"stock_qty": stock_map.get(code, 0),
+				"custom_control_level": row.get("custom_control_level") or "",
+			}
+		)
+	return result
+
+
+def _search_customers_impl(search_term=None, limit=20):
+	filters = {}
+	or_filters = None
+	if search_term and str(search_term).strip():
+		term = f"%{search_term.strip()}%"
+		or_filters = [["name", "like", term], ["customer_name", "like", term]]
+
+	return frappe.get_all(
+		"Customer",
+		filters=filters,
+		or_filters=or_filters,
+		fields=["name", "customer_name"],
+		limit_page_length=cint(limit),
+		order_by="customer_name asc",
+	)
+
+
+def _create_sales_order_from_cart_impl(
+	customer,
+	items,
+	delivery_date=None,
+	price_list=None,
+):
+	if isinstance(items, str):
+		items = parse_json(items)
+	if not customer:
+		frappe.throw(_("customer es obligatorio"))
+	if not items:
+		frappe.throw(_("items no puede estar vacio"))
+
+	company = _get_default_company()
+	party_details = get_party_details(
+		party=customer,
+		party_type="Customer",
+		company=company,
+		doctype="Sales Order",
+		price_list=price_list,
+	)
+
+	so = frappe.new_doc("Sales Order")
+	so.company = company
+	so.customer = customer
+	so.transaction_date = nowdate()
+	so.delivery_date = delivery_date or add_days(nowdate(), DEFAULT_DELIVERY_DAYS)
+	so.selling_price_list = price_list or party_details.get("selling_price_list")
+
+	default_warehouse = _get_default_warehouse(company)
+	if default_warehouse:
+		so.set_warehouse = default_warehouse
+
+	for field in (
+		"taxes_and_charges",
+		"customer_address",
+		"shipping_address_name",
+		"contact_person",
+		"currency",
+		"payment_terms_template",
+	):
+		if party_details.get(field):
+			so.set(field, party_details.get(field))
+
+	if not so.taxes_and_charges:
+		default_tax_template = frappe.db.get_value(
+			"Sales Taxes and Charges Template",
+			{"company": company},
+			"name",
+			order_by="creation asc",
+		)
+		if default_tax_template:
+			so.taxes_and_charges = default_tax_template
+
+	for row in items:
+		item_code = row.get("item_code")
+		if not item_code:
+			frappe.throw(_("Cada item debe incluir item_code"))
+		qty = flt(row.get("qty"))
+		if qty <= 0:
+			frappe.throw(_("Cantidad invalida para {0}").format(item_code))
+		item_row = {
+			"item_code": item_code,
+			"qty": qty,
+			"delivery_date": so.delivery_date,
+		}
+		if row.get("rate") is not None:
+			item_row["rate"] = flt(row.get("rate"))
+		so.append("items", item_row)
+
+	sales_person = _get_sales_person_for_user()
+	if sales_person:
+		so.set("sales_team", [])
+		so.append(
+			"sales_team",
+			{"sales_person": sales_person, "allocated_percentage": 100},
+		)
+
+	so.run_method("set_missing_values")
+	so.insert()
+
+	return {"name": so.name, "status": so.status}
+
+
+def _resolve_post_login_path_for_user(user: str | None = None) -> str:
+	"""Vendedor Terreno sin ningun rol con desk_access va al catalogo SPA; resto a Desk."""
+	user = user or frappe.session.user
+	if not user or user == "Guest":
+		return POST_LOGIN_DESK_PATH
+
+	roles = [role for role in frappe.get_roles(user) if role not in ("All", "Guest")]
+	has_vendedor_terreno = ROLE_VENDEDOR_TERRENO in roles
+	has_desk_access = any(
+		cint(frappe.db.get_value("Role", role, "desk_access"))
+		for role in roles
+		if frappe.db.exists("Role", role)
+	)
+
+	if has_vendedor_terreno and not has_desk_access:
+		return POST_LOGIN_CATALOGO_PATH
+	return POST_LOGIN_DESK_PATH
+
+
+@frappe.whitelist()
+def get_post_login_path():
+	if frappe.session.user in (None, "Guest"):
+		frappe.throw(_("Inicie sesion para continuar"), frappe.AuthenticationError)
+	return _resolve_post_login_path_for_user()
+
+
+@frappe.whitelist()
+def list_catalog_items(
+	search_term=None,
+	item_group=None,
+	price_list=None,
+	start=0,
+	page_length=20,
+):
+	_ensure_catalogo_access()
+	return _list_catalog_items_impl(
+		search_term=search_term,
+		item_group=item_group,
+		price_list=price_list,
+		start=start,
+		page_length=page_length,
+	)
+
+
+@frappe.whitelist()
+def list_item_groups():
+	_ensure_catalogo_access()
+	return frappe.get_all(
+		"Item Group",
+		filters={"is_group": 0},
+		fields=["name"],
+		order_by="name asc",
+	)
+
+
+@frappe.whitelist()
+def search_customers(search_term=None):
+	_ensure_catalogo_access()
+	return _search_customers_impl(search_term=search_term)
+
+
+@frappe.whitelist()
+def create_sales_order_from_cart(customer, items, delivery_date=None, price_list=None):
+	_ensure_catalogo_access()
+	return _create_sales_order_from_cart_impl(
+		customer=customer,
+		items=items,
+		delivery_date=delivery_date,
+		price_list=price_list,
+	)

--- a/barriofarma_app/barriofarma_app/tests/integration/test_catalogo_terreno_api.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_catalogo_terreno_api.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Barrio Farma and Contributors
+# See license.txt
+
+"""
+Tests integracion API catalogo terreno — issue whiteboard #75.
+
+Cubre escenarios S3, S5, S6, S7 del spec pos-sales-order-terreno.
+S1/S2/S4: cubiertos en tests frontend (Fase 5).
+S8: flujo nativo make_purchase_order ERPNext (sin test en este modulo).
+S9: verificacion negativa por revision de diff (no test automatizado).
+"""
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, nowdate
+
+from barriofarma_app.barriofarma_app.api.catalogo_terreno import (
+	create_sales_order_from_cart,
+	get_post_login_path,
+	list_catalog_items,
+	search_customers,
+)
+from barriofarma_app.barriofarma_app.test_setup import (
+	create_test_customer,
+	create_test_item,
+	create_test_warehouse,
+	ensure_minimum_masters,
+	get_test_company,
+)
+from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+	setup_permissions_for_role,
+)
+from barriofarma_app.barriofarma_app.utils.permissions.setup_roles import create_custom_roles
+from barriofarma_app.barriofarma_app.tests.integration.test_epic8_story82_role_authorization import (
+	create_test_user_with_role,
+)
+
+
+class TestCatalogoTerrenoApi(FrappeTestCase):
+	ROLE = "Vendedor Terreno"
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		ensure_minimum_masters()
+		create_custom_roles()
+		if not frappe.db.exists("Role", self.ROLE):
+			frappe.get_doc(
+				{
+					"doctype": "Role",
+					"role_name": self.ROLE,
+					"desk_access": 0,
+					"is_custom": 1,
+				}
+			).insert(ignore_permissions=True)
+		setup_permissions_for_role(self.ROLE, use_extended_strategy=True)
+		frappe.clear_cache()
+		self._cleanup = []
+		self.company = get_test_company()
+		self.warehouse = create_test_warehouse(
+			f"Almacen Catalogo Terreno {frappe.generate_hash(length=4)}",
+			company=self.company,
+		).name
+		self._track("Warehouse", self.warehouse)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name, doctype in reversed(self._cleanup):
+			try:
+				if frappe.db.exists(doctype, name):
+					doc = frappe.get_doc(doctype, name)
+					if getattr(doc, "docstatus", 0) == 1:
+						doc.cancel()
+					frappe.delete_doc(doctype, name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		frappe.db.commit()
+
+	def _track(self, doctype, name):
+		self._cleanup.append((name, doctype))
+
+	def _create_vendedor(self, username):
+		user = create_test_user_with_role(username, self.ROLE)
+		setup_permissions_for_role(self.ROLE, use_extended_strategy=True)
+		frappe.clear_cache()
+		return user.name
+
+	def _ensure_price_list(self):
+		pl_name = "Standard Selling"
+		if not frappe.db.exists("Price List", pl_name):
+			pl = frappe.get_doc(
+				{
+					"doctype": "Price List",
+					"price_list_name": pl_name,
+					"currency": frappe.db.get_value("Company", self.company, "default_currency")
+					or "CLP",
+					"selling": 1,
+					"enabled": 1,
+				}
+			)
+			pl.insert(ignore_permissions=True)
+			self._track("Price List", pl.name)
+			return pl.name
+		return pl_name
+
+	def _create_item_with_price(self, suffix, price_list, rate=1000):
+		item = create_test_item(
+			item_code=f"TEST-CAT-{suffix}",
+			custom_dispensing_type="Venta Libre",
+		)
+		self._track("Item", item.name)
+		if not frappe.db.exists(
+			"Item Price",
+			{"item_code": item.name, "price_list": price_list},
+		):
+			ip = frappe.get_doc(
+				{
+					"doctype": "Item Price",
+					"item_code": item.name,
+					"price_list": price_list,
+					"price_list_rate": rate,
+				}
+			)
+			ip.insert(ignore_permissions=True)
+			self._track("Item Price", ip.name)
+		return item.name
+
+	def test_s3_list_catalog_without_pos_profile(self):
+		"""S3: catalogo responde sin POS Profile ni POS Opening Entry."""
+		user_a = self._create_vendedor("vendedor_cat_a")
+		price_list = self._ensure_price_list()
+		item_code = self._create_item_with_price("S3", price_list)
+
+		frappe.set_user(user_a)
+		result = list_catalog_items(price_list=price_list, search_term="TEST-CAT-S3")
+		self.assertTrue(result)
+		codes = {row["item_code"] for row in result}
+		self.assertIn(item_code, codes)
+
+	def _ensure_sales_tax_template(self):
+		template_name = "IVA Ventas Catalogo Terreno"
+		company = self.company
+		if frappe.db.exists("Sales Taxes and Charges Template", template_name):
+			return template_name
+
+		account = frappe.db.get_value(
+			"Account",
+			{"company": company, "account_type": "Tax", "disabled": 0},
+			"name",
+		)
+		if not account:
+			account = frappe.db.get_value(
+				"Account",
+				{"company": company, "disabled": 0, "is_group": 0},
+				"name",
+			)
+		if not account:
+			self.skipTest("No hay cuenta contable para plantilla de impuestos en tests")
+
+		template = frappe.get_doc(
+			{
+				"doctype": "Sales Taxes and Charges Template",
+				"title": template_name,
+				"company": company,
+				"taxes": [
+					{
+						"charge_type": "On Net Total",
+						"account_head": account,
+						"description": "IVA",
+						"rate": 19,
+					}
+				],
+			}
+		)
+		template.insert(ignore_permissions=True)
+		self._track("Sales Taxes and Charges Template", template.name)
+		return template.name
+
+	def _ensure_sales_tax_rule(self, template_name):
+		existing = frappe.db.get_value(
+			"Tax Rule",
+			{
+				"tax_type": "Sales",
+				"company": self.company,
+				"sales_tax_template": template_name,
+			},
+			"name",
+		)
+		if existing:
+			return existing
+
+		rule = frappe.get_doc(
+			{
+				"doctype": "Tax Rule",
+				"tax_type": "Sales",
+				"company": self.company,
+				"sales_tax_template": template_name,
+				"priority": 1,
+			}
+		)
+		rule.insert(ignore_permissions=True)
+		self._track("Tax Rule", rule.name)
+		return rule.name
+
+	def test_s5_create_sales_order_defaults(self):
+		"""S5: delivery_date, taxes_and_charges y sales_team resueltos."""
+		user_a = self._create_vendedor("vendedor_cat_b")
+		price_list = self._ensure_price_list()
+		item_code = self._create_item_with_price("S5", price_list)
+		tax_template = self._ensure_sales_tax_template()
+		self._ensure_sales_tax_rule(tax_template)
+		customer = create_test_customer("Cliente Institucional S5")
+		self._track("Customer", customer.name)
+
+		employee = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Vendedor",
+				"last_name": "S5",
+				"employee_name": "Vendedor S5",
+				"company": self.company,
+				"status": "Active",
+				"user_id": user_a,
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": nowdate(),
+				"gender": "Male",
+			}
+		)
+		employee.insert(ignore_permissions=True)
+		self._track("Employee", employee.name)
+
+		sp_name = f"Vendedor S5 {frappe.generate_hash(length=4)}"
+		sales_person = frappe.get_doc(
+			{
+				"doctype": "Sales Person",
+				"sales_person_name": sp_name,
+				"employee": employee.name,
+				"enabled": 1,
+				"is_group": 0,
+			}
+		)
+		sales_person.insert(ignore_permissions=True)
+		self._track("Sales Person", sales_person.name)
+
+		frappe.set_user(user_a)
+		response = create_sales_order_from_cart(
+			customer=customer.name,
+			items=[{"item_code": item_code, "qty": 2, "rate": 1000}],
+			price_list=price_list,
+		)
+		self.assertTrue(response.get("name"))
+		so = frappe.get_doc("Sales Order", response["name"])
+		self.assertEqual(str(so.delivery_date), str(add_days(nowdate(), 7)))
+		self.assertTrue(so.taxes_and_charges)
+		self.assertEqual(so.owner, user_a)
+		self.assertEqual(len(so.sales_team), 1)
+		self.assertEqual(so.sales_team[0].sales_person, sales_person.name)
+		self._track("Sales Order", so.name)
+
+	def test_s6_sales_order_if_owner_isolation(self):
+		"""S6: vendedor A no lee Sales Order de vendedor B."""
+		user_a = self._create_vendedor("vendedor_cat_c")
+		user_b = self._create_vendedor("vendedor_cat_d")
+		price_list = self._ensure_price_list()
+		item_code = self._create_item_with_price("S6", price_list)
+		customer = create_test_customer("Cliente Institucional S6")
+		self._track("Customer", customer.name)
+
+		frappe.set_user(user_b)
+		response_b = create_sales_order_from_cart(
+			customer=customer.name,
+			items=[{"item_code": item_code, "qty": 1, "rate": 1000}],
+			price_list=price_list,
+		)
+		so_b = response_b["name"]
+		self._track("Sales Order", so_b)
+
+		frappe.set_user(user_a)
+		self.assertFalse(frappe.has_permission("Sales Order", "read", so_b))
+		with self.assertRaises(frappe.PermissionError):
+			frappe.get_doc("Sales Order", so_b, check_permission=True)
+
+	def test_s7_search_customers_created_by_other_user(self):
+		"""S7: busqueda amplia de Customer sin if_owner."""
+		user_a = self._create_vendedor("vendedor_cat_e")
+		customer = create_test_customer("Institucional Compartido S7")
+		self._track("Customer", customer.name)
+
+		frappe.set_user(user_a)
+		results = search_customers(search_term="Institucional Compartido S7")
+		names = {row["name"] for row in results}
+		self.assertIn(customer.name, names)
+
+	def test_post_login_path_vendedor_terreno_to_catalogo(self):
+		"""Vendedor Terreno sin desk_access redirige al catalogo SPA."""
+		user = self._create_vendedor("vendedor_cat_redirect")
+		frappe.set_user(user)
+		self.assertEqual(get_post_login_path(), "/inicio/catalogo")
+
+	def test_post_login_path_desk_user_to_app(self):
+		"""Usuario con rol de desk_access sigue yendo a /app."""
+		user = create_test_user_with_role("auxiliar_redirect", "Auxiliar")
+		frappe.set_user(user.name)
+		self.assertEqual(get_post_login_path(), "/app")

--- a/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
+++ b/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
@@ -28,6 +28,7 @@ Buenas prácticas de Frappe:
 import frappe
 from frappe import _
 import logging
+from frappe.utils import cint
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +163,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Product Bundle": {
         "Farmacéutico": ["R", "W", "C"],
@@ -226,7 +228,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Customer": {
         "Farmacéutico": ["R", "W", "C"],
@@ -234,7 +237,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": [],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R", "W", "C"],
     },
     "Customer Group": {
         "Farmacéutico": ["R"],
@@ -306,7 +310,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R", "W", "C"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Currency": {
         "Farmacéutico": ["R"],
@@ -314,7 +319,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Item Price": {
         "Farmacéutico": ["R", "W", "C"],
@@ -322,7 +328,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R", "W", "C"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "POS Opening Entry": {
         "Farmacéutico": ["R", "W", "C", "S"],  # Necesita crear y validar POS Opening Entry para usar el POS
@@ -388,7 +395,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     # Recibo de compra / PO leen configuración global de compras (purchase_receipt.js)
     "Buying Settings": {
@@ -413,7 +421,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Serial and Batch Bundle": {
         "Farmacéutico": ["R"],
@@ -445,7 +454,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": [],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Purchase Invoice": {
         "Farmacéutico": ["R"],  # Consulta facturas de compra (sin contabilizar)
@@ -549,7 +559,17 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R", "C"],
+    },
+    "Sales Person": {
+        "Farmacéutico": ["R"],
+        "Auxiliar": ["R"],
+        "Bodeguero": [],
+        "Administrativo": ["R"],
+        "Contabilidad": ["R"],
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Company": {
         "Farmacéutico": ["R"],
@@ -557,7 +577,8 @@ PERMISSIONS_MATRIX = {
         "Bodeguero": ["R"],
         "Administrativo": ["R", "W", "C"],
         "Contabilidad": ["R"],
-        "Informática": ["R", "W", "C", "D", "S", "X"]
+        "Informática": ["R", "W", "C", "D", "S", "X"],
+        "Vendedor Terreno": ["R"],
     },
     "Letter Head": {
         "Farmacéutico": ["R"],
@@ -578,7 +599,12 @@ PERMISSIONS_MATRIX = {
 
 # Roles operativos UAT: solo DocTypes en PERMISSIONS_MATRIX (o base módulo explícito).
 # Evita que la estrategia extendida herede permisos genéricos de ERPNext por módulo.
-OPERATIONAL_WHITELIST_ROLES = frozenset({"Farmacéutico", "Auxiliar"})
+OPERATIONAL_WHITELIST_ROLES = frozenset({"Farmacéutico", "Auxiliar", "Vendedor Terreno"})
+
+# Permisos con if_owner=1 por (doctype, role). Default if_owner=0 para el resto.
+PERMISSIONS_IF_OWNER = {
+    ("Sales Order", "Vendedor Terreno"): 1,
+}
 
 # Perfiles administración/contabilidad: permisos vía roles estándar ERPNext (Accounts Manager, …).
 # No aplicar estrategia extendida ni matriz; Administrativo/Contabilidad son etiquetas de perfil/escritorio.
@@ -707,8 +733,12 @@ def _ensure_custom_perm_bootstrap(doctype):
 	frappe.permissions.setup_custom_perms(doctype)
 
 
-def _custom_docperm_filters(doctype, role, permlevel=0):
-	return {"parent": doctype, "role": role, "permlevel": permlevel, "if_owner": 0}
+def _custom_docperm_filters(doctype, role, permlevel=0, if_owner=0):
+	return {"parent": doctype, "role": role, "permlevel": permlevel, "if_owner": cint(if_owner)}
+
+
+def _get_if_owner_for_role(doctype, role):
+	return PERMISSIONS_IF_OWNER.get((doctype, role), 0)
 
 
 def _set_docperm_on_custom_doctype(doctype, role, perm_values, permlevel=0):
@@ -734,7 +764,7 @@ def _set_docperm_on_custom_doctype(doctype, role, perm_values, permlevel=0):
 	return True
 
 
-def _remove_docperm_on_custom_doctype(doctype, role, permlevel=0):
+def _remove_docperm_on_custom_doctype(doctype, role, permlevel=0, if_owner=0):
 	"""Legacy path: remove DocPerm row on custom DocTypes via DocType.save()."""
 	doc = frappe.get_doc("DocType", doctype)
 	before = len(doc.permissions)
@@ -744,7 +774,9 @@ def _remove_docperm_on_custom_doctype(doctype, role, permlevel=0):
 	if len(doc.permissions) < before:
 		doc.save(ignore_permissions=True)
 
-	custom_name = frappe.db.get_value("Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel))
+	custom_name = frappe.db.get_value(
+		"Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel, if_owner)
+	)
 	if custom_name:
 		frappe.delete_doc("Custom DocPerm", custom_name, ignore_permissions=True, force=True)
 
@@ -752,14 +784,16 @@ def _remove_docperm_on_custom_doctype(doctype, role, permlevel=0):
 	return True
 
 
-def _apply_custom_docperm(doctype, role, perm_values, permlevel=0):
+def _apply_custom_docperm(doctype, role, perm_values, permlevel=0, if_owner=0):
 	"""Materialize perm_values in Custom DocPerm. No DocType.save on standard doctypes."""
 	if frappe.db.get_value("DocType", doctype, "custom"):
 		return _set_docperm_on_custom_doctype(doctype, role, perm_values, permlevel)
 
 	try:
 		_ensure_custom_perm_bootstrap(doctype)
-		custom_name = frappe.db.get_value("Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel))
+		custom_name = frappe.db.get_value(
+			"Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel, if_owner)
+		)
 		if custom_name:
 			custom = frappe.get_doc("Custom DocPerm", custom_name)
 			for key, value in perm_values.items():
@@ -774,7 +808,7 @@ def _apply_custom_docperm(doctype, role, perm_values, permlevel=0):
 					"parentfield": "permissions",
 					"role": role,
 					"permlevel": permlevel,
-					"if_owner": 0,
+					"if_owner": cint(if_owner),
 					**perm_values,
 				}
 			).insert(ignore_permissions=True)
@@ -786,13 +820,15 @@ def _apply_custom_docperm(doctype, role, perm_values, permlevel=0):
 		return False
 
 
-def _delete_custom_docperm_row(doctype, role, permlevel=0):
+def _delete_custom_docperm_row(doctype, role, permlevel=0, if_owner=0):
 	"""Delete Custom DocPerm row for role. Idempotent when row is missing."""
 	if frappe.db.get_value("DocType", doctype, "custom"):
-		return _remove_docperm_on_custom_doctype(doctype, role, permlevel)
+		return _remove_docperm_on_custom_doctype(doctype, role, permlevel, if_owner)
 
 	try:
-		custom_name = frappe.db.get_value("Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel))
+		custom_name = frappe.db.get_value(
+			"Custom DocPerm", _custom_docperm_filters(doctype, role, permlevel, if_owner)
+		)
 		if not custom_name:
 			return True
 		frappe.delete_doc("Custom DocPerm", custom_name, ignore_permissions=True, force=True)
@@ -804,7 +840,7 @@ def _delete_custom_docperm_row(doctype, role, permlevel=0):
 		return False
 
 
-def remove_docperm(doctype, role, permlevel=0):
+def remove_docperm(doctype, role, permlevel=0, if_owner=None):
 	"""
 	Elimina permisos del rol en el DocType.
 
@@ -814,15 +850,18 @@ def remove_docperm(doctype, role, permlevel=0):
 	if not frappe.db.exists("DocType", doctype) or not frappe.db.exists("Role", role):
 		return False
 
+	if if_owner is None:
+		if_owner = _get_if_owner_for_role(doctype, role)
+
 	try:
-		return _delete_custom_docperm_row(doctype, role, permlevel)
+		return _delete_custom_docperm_row(doctype, role, permlevel, if_owner)
 	except Exception as e:
 		logger.error(f"Error al quitar permiso {doctype}/{role}: {e}")
 		frappe.db.rollback()
 		return False
 
 
-def set_docperm(doctype, role, permissions, permlevel=0):
+def set_docperm(doctype, role, permissions, permlevel=0, if_owner=None):
 	"""
 	Configurar permisos para un DocType y rol específico
 
@@ -831,6 +870,7 @@ def set_docperm(doctype, role, permissions, permlevel=0):
 		role: Nombre del rol
 		permissions: Lista de permisos ['R', 'W', 'C', 'D', 'S', 'X']
 		permlevel: Nivel de permiso (0 = nivel base)
+		if_owner: 1 para permisos restringidos al owner; None usa PERMISSIONS_IF_OWNER
 	"""
 	if not frappe.db.exists("DocType", doctype):
 		logger.warning(f"DocType '{doctype}' no existe, omitiendo configuración de permisos")
@@ -840,13 +880,22 @@ def set_docperm(doctype, role, permissions, permlevel=0):
 		logger.warning(f"Rol '{role}' no existe, omitiendo configuración de permisos")
 		return False
 
+	if if_owner is None:
+		if_owner = _get_if_owner_for_role(doctype, role)
+
 	if not permissions:
-		return _delete_custom_docperm_row(doctype, role, permlevel)
+		return _delete_custom_docperm_row(doctype, role, permlevel, if_owner)
 
 	try:
+		# Evitar filas duplicadas (if_owner=0 y if_owner=1) que amplían permisos por OR en Frappe.
+		if cint(if_owner):
+			_delete_custom_docperm_row(doctype, role, permlevel, if_owner=0)
+		else:
+			_delete_custom_docperm_row(doctype, role, permlevel, if_owner=1)
+
 		is_submittable = frappe.db.get_value("DocType", doctype, "is_submittable")
 		perm_values = _build_perm_values(permissions, is_submittable)
-		return _apply_custom_docperm(doctype, role, perm_values, permlevel)
+		return _apply_custom_docperm(doctype, role, perm_values, permlevel, if_owner)
 	except Exception as e:
 		logger.error(f"Error al configurar permiso para {doctype}/{role}: {str(e)}")
 		frappe.db.rollback()
@@ -900,13 +949,14 @@ def setup_permissions_for_role(role_name, use_extended_strategy=True):
             permissions = get_doctype_permissions(doctype, role_name)
             
             if permissions is not None:
+                if_owner = _get_if_owner_for_role(doctype, role_name)
                 if permissions:
-                    if set_docperm(doctype, role_name, permissions):
+                    if set_docperm(doctype, role_name, permissions, if_owner=if_owner):
                         configured += 1
                         logger.debug(f"  {doctype}: {', '.join(permissions)}")
                     else:
                         skipped += 1
-                elif remove_docperm(doctype, role_name):
+                elif remove_docperm(doctype, role_name, if_owner=if_owner):
                     configured += 1
                     logger.debug(f"  {doctype}: permiso eliminado (sin acceso)")
                 else:
@@ -917,8 +967,9 @@ def setup_permissions_for_role(role_name, use_extended_strategy=True):
         for doctype, roles_perms in PERMISSIONS_MATRIX.items():
             if role_name in roles_perms:
                 permissions = roles_perms[role_name]
+                if_owner = _get_if_owner_for_role(doctype, role_name)
                 if permissions:
-                    if set_docperm(doctype, role_name, permissions):
+                    if set_docperm(doctype, role_name, permissions, if_owner=if_owner):
                         configured += 1
                         perms_str = ", ".join(permissions)
                         logger.debug(f"  {doctype}: {perms_str}")
@@ -945,7 +996,8 @@ def setup_all_permissions(use_extended_strategy=True):
         "Bodeguero",
         "Administrativo",
         "Contabilidad",
-        "Informática"
+        "Informática",
+        "Vendedor Terreno",
     ]
     
     if use_extended_strategy:

--- a/barriofarma_app/barriofarma_app/utils/permissions/setup_roles.py
+++ b/barriofarma_app/barriofarma_app/utils/permissions/setup_roles.py
@@ -48,6 +48,11 @@ def create_custom_roles():
             "name": "Informática",
             "desk_access": 1,
             "description": "Rol para personal de informática. Acceso técnico completo y configuración avanzada."
+        },
+        {
+            "name": "Vendedor Terreno",
+            "desk_access": 0,
+            "description": "Rol para vendedores en terreno. Acceso solo via SPA inicio/API REST (catalogo, carrito, Sales Order propias)."
         }
     ]
     
@@ -100,7 +105,8 @@ def verify_roles():
         "Bodeguero",
         "Administrativo",
         "Contabilidad",
-        "Informática"
+        "Informática",
+        "Vendedor Terreno"
     ]
     
     logger.info("=== Verificación de Roles Requeridos ===")


### PR DESCRIPTION
Closes barriofarmacl/whiteboard#75

## Type
- [x] New feature

## Summary
- Adds the whitelisted terrain catalog and Sales Order API.
- Adds `Vendedor Terreno` role and owner-isolated permissions.
- Covers catalog, order defaults, isolation, customer search, and post-login behavior with integration tests.

## Test plan
- [x] Frappe integration suite: 6 scenarios passed during SDD verify.
- [x] Diff does not modify ERPNext POS core.

## Chain context
- Chain: terrain-sales-order-and-inicio-quality
- Position: 1 of 3 (application)
- Base: `develop`
- Depends on: none
- Follow-up: `feat/pos-sales-order-terreno-frontend`
- Review budget: 771 changed lines; cohesive exception keeps API and integration tests together.

```text
develop
└── [CURRENT] backend API and permissions
    └── frontend catalog workflow
        └── frontend quality bar
```

## Scope
- Includes: backend API, roles, permissions, integration tests.
- Excludes: SPA implementation and visual quality bar.