### PR TITLE
feat(inicio): enforce brand frontend quality bar

### DIFF
--- a/inicio/README.md
+++ b/inicio/README.md
@@ -12,9 +12,15 @@
 
 No se usa **Frappe UI (Vue 3)** en esta SPA. Las guías y skills que lo prescriben (p. ej. `frappe-frontend-development`) aplican solo como **referencia de buenas prácticas** (proxy, auth, loading, build), no como mandato de migración: **no hay plan de pasar esta SPA a Vue**.
 
-Alcance actual acordado: **landing informativa** y **login** hacia el Desk (`/app`). Nuevas pantallas deben seguir el mismo patrón: **SDK + cookies**; evitar `fetch` ad hoc que ignore la sesión.
+Alcance actual acordado: **landing informativa**, **login** hacia el Desk (`/app`) o catalogo terreno (`/inicio/catalogo` segun rol), y **catalogo + carrito** para vendedores en terreno. Nuevas pantallas deben seguir el mismo patron: **SDK + cookies**; evitar `fetch` ad hoc que ignore la sesion.
 
-**Fecha de ratificación:** 2026-04-20 (decisión explícita del equipo).
+**Arquitectura frontend (ADR):** ver [adr_inicio_frontend_architecture.md](../../../../.cursor/docs/development/adr_inicio_frontend_architecture.md) (submodule methodology en monorepo dev).
+
+**Design tokens:** ver [docs/DESIGN_TOKENS.md](docs/DESIGN_TOKENS.md).
+
+**Feature catalogo:** `src/features/catalogo/` (api, hooks, context, components).
+
+**Fecha de ratificacion stack:** 2026-04-20 (React+shadcn+sdk). **Gate calidad brand:** 2026-07-11 (Architect).
 
 ---
 

--- a/inicio/docs/DESIGN_TOKENS.md
+++ b/inicio/docs/DESIGN_TOKENS.md
@@ -1,0 +1,34 @@
+# Design tokens — SPA `inicio`
+
+Referencia Capa 3 del [ADR](../../../../.cursor/docs/development/adr_inicio_frontend_architecture.md).
+
+## Paleta (HSL en `src/index.css`)
+
+| Token CSS | Uso |
+|-----------|-----|
+| `--primary` | CTAs, titulos de seccion, acentos app |
+| `--secondary` | Acento salud / links secundarios |
+| `--brand` | Header/footer landing, hero |
+| `--background` | Fondo pagina (crema calido) |
+| `--muted` | Secciones alternas, superficies suaves |
+| `--card` | Tarjetas elevadas |
+| `--border` | Bordes |
+
+## Tipografia
+
+| Rol | Familia |
+|-----|---------|
+| Display / headings | Fraunces |
+| Body / UI | Source Sans 3 |
+
+## Clases utilitarias (`index.css`)
+
+- `bf-section-muted` — seccion con fondo muted
+- `bf-surface-card` — tarjeta con borde y sombra
+- `bf-heading-section` — titulo de seccion landing
+- `bf-text-muted` — texto secundario
+
+## Reglas
+
+- Preferir tokens semanticos (`bg-primary`, `text-muted-foreground`) sobre `purple-*` / `gray-*` hardcodeados.
+- Botones: variant `default` usa `--primary`; no override `bg-purple-700` salvo excepcion documentada.

--- a/inicio/eslint.config.js
+++ b/inicio/eslint.config.js
@@ -1,0 +1,36 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
+
+export default tseslint.config(
+  { ignores: ['dist', '../barriofarma_app/public/inicio'] },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        {
+          allowConstantExport: true,
+          allowExportNames: [
+            'buttonVariants',
+            'CartContext',
+            'CartProvider',
+            'useCart',
+          ],
+        },
+      ],
+    },
+  },
+)

--- a/inicio/proxyOptions.ts
+++ b/inicio/proxyOptions.ts
@@ -1,3 +1,5 @@
+// The dev proxy loads Bench runtime configuration outside the Vite source tree.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const common_site_config = require('../../../sites/common_site_config.json');
 const { webserver_port } = common_site_config;
 

--- a/inicio/src/components/landing/LandingCategories.tsx
+++ b/inicio/src/components/landing/LandingCategories.tsx
@@ -6,14 +6,14 @@ export function LandingCategories() {
   return (
     <section
       id={SECTION_IDS.categorias}
-      className="py-16 bg-gray-50"
+      className="py-16 bf-section-muted"
       aria-labelledby="landing-cat-title"
     >
       <div className="container mx-auto px-4">
-        <h2 id="landing-cat-title" className="text-3xl font-bold text-center mb-4 text-purple-800">
+        <h2 id="landing-cat-title" className="bf-heading-section mb-4">
           Categorias informativas
         </h2>
-        <p className="text-center text-gray-600 max-w-2xl mx-auto mb-12">
+        <p className="text-center bf-text-muted max-w-2xl mx-auto mb-12">
           Referencia general de lineas que trabajamos en sucursal. Disponibilidad y marcas se confirman
           directamente en farmacia; esta web no es catalogo de venta.
         </p>
@@ -30,12 +30,10 @@ export function LandingCategories() {
                     height={64}
                   />
                 </div>
-                <CardTitle className="text-lg text-purple-800 text-center">{category.title}</CardTitle>
+                <CardTitle className="text-lg text-primary text-center">{category.title}</CardTitle>
               </CardHeader>
               <CardContent>
-                <CardDescription className="text-center text-gray-600">
-                  {category.description}
-                </CardDescription>
+                <CardDescription className="text-center">{category.description}</CardDescription>
               </CardContent>
             </Card>
           ))}

--- a/inicio/src/components/landing/LandingContact.tsx
+++ b/inicio/src/components/landing/LandingContact.tsx
@@ -4,44 +4,44 @@ import { SECTION_IDS, CONTACT } from '@/lib/site-content'
 
 export function LandingContact() {
   return (
-    <section id={SECTION_IDS.contacto} className="bg-gray-50 py-16" aria-labelledby="landing-contact-title">
+    <section id={SECTION_IDS.contacto} className="bf-section-muted py-16" aria-labelledby="landing-contact-title">
       <div className="container mx-auto px-4">
-        <h2 id="landing-contact-title" className="text-3xl font-bold text-center mb-12 text-purple-800">
+        <h2 id="landing-contact-title" className="bf-heading-section mb-12">
           Informacion de contacto
         </h2>
         <div className="grid md:grid-cols-3 gap-8">
-          <div className="bg-white p-6 rounded-lg shadow-md flex flex-col items-center text-center">
-            <MapPin className="h-10 w-10 text-purple-700 mb-4" aria-hidden />
+          <div className="bf-surface-card p-6 flex flex-col items-center text-center">
+            <MapPin className="h-10 w-10 text-primary mb-4" aria-hidden />
             <h3 className="font-semibold mb-2">Direccion</h3>
-            <p className="text-gray-600">{CONTACT.addressLine}</p>
+            <p className="bf-text-muted">{CONTACT.addressLine}</p>
           </div>
-          <div className="bg-white p-6 rounded-lg shadow-md flex flex-col items-center text-center">
-            <Clock className="h-10 w-10 text-purple-700 mb-4" aria-hidden />
+          <div className="bf-surface-card p-6 flex flex-col items-center text-center">
+            <Clock className="h-10 w-10 text-primary mb-4" aria-hidden />
             <h3 className="font-semibold mb-2">Horario</h3>
             {CONTACT.schedule.map((line) => (
-              <p key={line} className="text-gray-600">
+              <p key={line} className="bf-text-muted">
                 {line}
               </p>
             ))}
           </div>
-          <div className="bg-white p-6 rounded-lg shadow-md flex flex-col items-center text-center">
-            <Phone className="h-10 w-10 text-purple-700 mb-4" aria-hidden />
+          <div className="bf-surface-card p-6 flex flex-col items-center text-center">
+            <Phone className="h-10 w-10 text-primary mb-4" aria-hidden />
             <h3 className="font-semibold mb-2">Telefono</h3>
-            <p className="text-gray-600">
+            <p className="bf-text-muted">
               {CONTACT.phoneDisplay.includes('X') ? (
                 <span>{CONTACT.phoneDisplay}</span>
               ) : (
                 <a
-                  className="underline hover:text-purple-800"
+                  className="underline hover:text-primary"
                   href={`tel:${CONTACT.phoneDisplay.replace(/[^\d+]/g, '')}`}
                 >
                   {CONTACT.phoneDisplay}
                 </a>
               )}
             </p>
-            <p className="text-gray-600 mt-4 flex items-center gap-2">
-              <Mail className="h-4 w-4 text-purple-700 shrink-0" aria-hidden />
-              <a className="underline hover:text-purple-800" href={`mailto:${CONTACT.email}`}>
+            <p className="bf-text-muted mt-4 flex items-center gap-2">
+              <Mail className="h-4 w-4 text-primary shrink-0" aria-hidden />
+              <a className="underline hover:text-primary" href={`mailto:${CONTACT.email}`}>
                 {CONTACT.email}
               </a>
             </p>

--- a/inicio/src/components/landing/LandingFooter.tsx
+++ b/inicio/src/components/landing/LandingFooter.tsx
@@ -4,20 +4,20 @@ import { CONTACT, FOOTER_QUICK, SITE } from '@/lib/site-content'
 
 export function LandingFooter() {
   return (
-    <footer className="bg-purple-800 text-white py-8">
+    <footer className="bg-brand text-brand-foreground py-8">
       <div className="container mx-auto px-4">
         <div className="grid md:grid-cols-3 gap-8">
           <div>
-            <h3 className="text-lg font-semibold mb-4">{SITE.brand}</h3>
-            <p className="text-gray-200">{SITE.tagline}</p>
-            <p className="text-gray-300 text-sm mt-3">Sin venta online. Atencion en sucursal.</p>
+            <h3 className="text-lg font-semibold mb-4 font-display">{SITE.brand}</h3>
+            <p className="text-brand-foreground/85">{SITE.tagline}</p>
+            <p className="text-brand-foreground/70 text-sm mt-3">Sin venta online. Atencion en sucursal.</p>
           </div>
           <div>
-            <h3 className="text-lg font-semibold mb-4">Enlaces</h3>
+            <h3 className="text-lg font-semibold mb-4 font-display">Enlaces</h3>
             <ul className="space-y-2">
               {FOOTER_QUICK.map((item) => (
                 <li key={item.href}>
-                  <a href={item.href} className="text-gray-200 hover:text-white">
+                  <a href={item.href} className="text-brand-foreground/85 hover:text-brand-foreground">
                     {item.label}
                   </a>
                 </li>
@@ -25,8 +25,8 @@ export function LandingFooter() {
             </ul>
           </div>
           <div>
-            <h3 className="text-lg font-semibold mb-4">Contacto</h3>
-            <div className="space-y-2 text-gray-200">
+            <h3 className="text-lg font-semibold mb-4 font-display">Contacto</h3>
+            <div className="space-y-2 text-brand-foreground/85">
               <p className="flex items-start">
                 <MapPin className="h-4 w-4 mr-2 mt-1 shrink-0" aria-hidden />
                 {CONTACT.addressShort}
@@ -37,7 +37,7 @@ export function LandingFooter() {
                   <span>{CONTACT.phoneDisplay}</span>
                 ) : (
                   <a
-                    className="hover:text-white underline"
+                    className="hover:text-brand-foreground underline"
                     href={`tel:${CONTACT.phoneDisplay.replace(/[^\d+]/g, '')}`}
                   >
                     {CONTACT.phoneDisplay}
@@ -46,14 +46,14 @@ export function LandingFooter() {
               </p>
               <p className="flex items-center">
                 <Mail className="h-4 w-4 mr-2 shrink-0" aria-hidden />
-                <a className="hover:text-white underline" href={`mailto:${CONTACT.email}`}>
+                <a className="hover:text-brand-foreground underline" href={`mailto:${CONTACT.email}`}>
                   {CONTACT.email}
                 </a>
               </p>
             </div>
           </div>
         </div>
-        <div className="border-t border-purple-700 mt-8 pt-8 text-center text-gray-200">
+        <div className="border-t border-brand-muted mt-8 pt-8 text-center text-brand-foreground/85">
           <p>&copy; {new Date().getFullYear()} {SITE.brand}. Todos los derechos reservados.</p>
         </div>
       </div>

--- a/inicio/src/components/landing/LandingHeader.tsx
+++ b/inicio/src/components/landing/LandingHeader.tsx
@@ -7,15 +7,15 @@ export function LandingHeader() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
-    <header className="border-b bg-purple-800 relative">
+    <header className="border-b border-brand-muted/40 bg-brand relative">
       <div className="container mx-auto px-4 py-3">
         <div className="flex items-center justify-between">
-          <a href={`#${SECTION_IDS.hero}`} className="text-2xl font-bold text-white">
+          <a href={`#${SECTION_IDS.hero}`} className="text-2xl font-bold font-display text-brand-foreground">
             {SITE.brand}
           </a>
           <button
             type="button"
-            className="md:hidden text-white"
+            className="md:hidden text-brand-foreground"
             onClick={() => setIsMenuOpen((o) => !o)}
             aria-label={isMenuOpen ? 'Cerrar menu' : 'Abrir menu'}
             aria-expanded={isMenuOpen}
@@ -25,14 +25,14 @@ export function LandingHeader() {
           <nav
             className={`${
               isMenuOpen ? 'flex' : 'hidden'
-            } md:flex flex-col md:flex-row absolute md:relative top-full left-0 right-0 bg-purple-800 md:bg-transparent z-50 md:space-x-6 text-gray-100`}
+            } md:flex flex-col md:flex-row absolute md:relative top-full left-0 right-0 bg-brand md:bg-transparent z-50 md:space-x-6 text-brand-foreground/90`}
             aria-label="Principal"
           >
             {NAV_LINKS.map((item) => (
               <a
                 key={item.href}
                 href={item.href}
-                className="px-4 py-2 hover:bg-purple-700 md:hover:bg-transparent md:hover:text-white"
+                className="px-4 py-2 hover:bg-brand-muted md:hover:bg-transparent md:hover:text-brand-foreground"
                 onClick={() => setIsMenuOpen(false)}
               >
                 {item.label}
@@ -40,7 +40,7 @@ export function LandingHeader() {
             ))}
             <Link
               to="/inicio/login"
-              className="px-4 py-2 hover:bg-purple-700 md:hover:bg-transparent md:hover:text-white border-t border-purple-700 md:border-0"
+              className="px-4 py-2 hover:bg-brand-muted md:hover:bg-transparent md:hover:text-brand-foreground border-t border-brand-muted md:border-0"
               onClick={() => setIsMenuOpen(false)}
             >
               Acceso equipo

--- a/inicio/src/components/landing/LandingHero.tsx
+++ b/inicio/src/components/landing/LandingHero.tsx
@@ -7,7 +7,7 @@ export function LandingHero() {
   return (
     <section
       id={SECTION_IDS.hero}
-      className="bg-purple-700 text-white py-16"
+      className="bg-primary text-primary-foreground py-16"
       aria-labelledby="landing-hero-title"
     >
       <div className="container mx-auto px-4">
@@ -16,7 +16,7 @@ export function LandingHero() {
             <h1 id="landing-hero-title" className="text-4xl md:text-5xl font-bold mb-4">
               {HERO.title}
             </h1>
-            <p className="text-lg mb-6 text-purple-100">{HERO.subtitle}</p>
+            <p className="text-lg mb-6 text-primary-foreground/85">{HERO.subtitle}</p>
             <Button variant="secondary" size="lg" asChild>
               <a href={HERO.ctaHref} className="flex items-center">
                 {HERO.ctaLabel}
@@ -28,7 +28,7 @@ export function LandingHero() {
             <img
               src={assetBfSvg}
               alt={HERO.imageAlt}
-              className="rounded-lg w-full max-w-sm h-auto bg-white/10 p-8"
+              className="rounded-lg w-full max-w-sm h-auto bg-primary-foreground/10 p-8"
               width={320}
               height={320}
             />

--- a/inicio/src/components/landing/LandingServices.tsx
+++ b/inicio/src/components/landing/LandingServices.tsx
@@ -6,10 +6,10 @@ export function LandingServices() {
   return (
     <section id={SECTION_IDS.servicios} className="py-16" aria-labelledby="landing-svc-title">
       <div className="container mx-auto px-4">
-        <h2 id="landing-svc-title" className="text-3xl font-bold text-center mb-4 text-purple-800">
+        <h2 id="landing-svc-title" className="bf-heading-section mb-4">
           Servicios en sucursal
         </h2>
-        <p className="text-center text-gray-600 max-w-2xl mx-auto mb-12">
+        <p className="text-center bf-text-muted max-w-2xl mx-auto mb-12">
           Trabajamos con atencion presencial. Si necesitas un producto, consulta en tienda o por los medios
           de contacto indicados abajo.
         </p>
@@ -17,10 +17,10 @@ export function LandingServices() {
           {SERVICES.map((service) => (
             <Card key={service.title}>
               <CardHeader>
-                <CardTitle className="text-xl text-purple-800">{service.title}</CardTitle>
+                <CardTitle className="text-xl text-primary">{service.title}</CardTitle>
               </CardHeader>
               <CardContent>
-                <p className="text-gray-600">{service.body}</p>
+                <p className="bf-text-muted">{service.body}</p>
               </CardContent>
             </Card>
           ))}

--- a/inicio/src/components/ui/input.tsx
+++ b/inicio/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "../../lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/inicio/src/components/ui/use-toast.tsx
+++ b/inicio/src/components/ui/use-toast.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import { toast } from "sonner"
 
 export function useToast() {

--- a/inicio/src/pages/login-page.tsx
+++ b/inicio/src/pages/login-page.tsx
@@ -10,14 +10,21 @@ import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { getLoginErrorMessage } from '@/lib/auth-errors'
 import { normalizeLoginUsername, validateLoginEmail, validateLoginPassword } from '@/lib/login-validation'
+import { DESK_PATH, fetchPostLoginPath } from '@/lib/post-login-redirect'
 
 type FormValues = {
   email: string
   password: string
 }
 
-/** Destino tras login exitoso: Desk ERPNext/Frappe (backoffice). */
-const DESK_PATH = '/app'
+async function redirectAfterLogin() {
+  try {
+    const path = await fetchPostLoginPath()
+    window.location.assign(path)
+  } catch {
+    window.location.assign(DESK_PATH)
+  }
+}
 
 export default function LoginPage() {
   const { login, currentUser, isLoading: authLoading, updateCurrentUser } = useFrappeAuth()
@@ -36,7 +43,7 @@ export default function LoginPage() {
   useEffect(() => {
     if (authLoading) return
     if (currentUser) {
-      window.location.assign(DESK_PATH)
+      void redirectAfterLogin()
     }
   }, [authLoading, currentUser])
 
@@ -56,7 +63,7 @@ export default function LoginPage() {
       })
       updateCurrentUser()
       toast.success('Sesion iniciada')
-      window.location.assign(DESK_PATH)
+      await redirectAfterLogin()
     } catch (e) {
       toast.error(getLoginErrorMessage(e))
     } finally {
@@ -66,18 +73,18 @@ export default function LoginPage() {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <Loader2 className="h-10 w-10 animate-spin text-purple-700" aria-label="Cargando" />
+      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <Loader2 className="h-10 w-10 animate-spin text-primary" aria-label="Cargando" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold text-center text-purple-700">Barriofarma</CardTitle>
-          <CardDescription className="text-center text-gray-600">Cerca de ti</CardDescription>
+          <CardTitle className="text-2xl font-bold text-center text-primary font-display">Barriofarma</CardTitle>
+          <CardDescription className="text-center">Cerca de ti</CardDescription>
         </CardHeader>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <CardContent className="space-y-4">
@@ -120,7 +127,7 @@ export default function LoginPage() {
                 <button
                   type="button"
                   onClick={() => setShowPassword((s) => !s)}
-                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-muted-foreground hover:text-foreground"
                   aria-label={showPassword ? 'Ocultar contrasena' : 'Mostrar contrasena'}
                 >
                   {showPassword ? <EyeOffIcon className="h-5 w-5" /> : <EyeIcon className="h-5 w-5" />}
@@ -134,11 +141,7 @@ export default function LoginPage() {
             </div>
           </CardContent>
           <CardFooter className="flex flex-col space-y-4">
-            <Button
-              type="submit"
-              className="w-full bg-purple-700 hover:bg-purple-800 text-white"
-              disabled={submitting}
-            >
+            <Button type="submit" className="w-full" disabled={submitting}>
               {submitting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
@@ -148,14 +151,14 @@ export default function LoginPage() {
                 'Iniciar sesion'
               )}
             </Button>
-            <div className="text-sm text-center text-gray-600">
+            <div className="text-sm text-center text-muted-foreground">
               ¿No recuerdas tu contrasena?{' '}
-              <a href="/login#forgot" className="text-purple-700 hover:underline">
+              <a href="/login#forgot" className="text-primary hover:underline">
                 Recuperar
               </a>
             </div>
             <div className="text-sm text-center">
-              <Link to="/inicio" className="text-gray-500 hover:text-purple-700">
+              <Link to="/inicio" className="text-muted-foreground hover:text-primary">
                 Volver al inicio
               </Link>
             </div>

--- a/inicio/yarn.lock
+++ b/inicio/yarn.lock
@@ -1190,15 +1190,10 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-caniuse-lite@^1.0.30001646:
-  version "1.0.30001679"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz#18c573b72f72ba70822194f6c39e7888597f9e32"
-  integrity sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==
-
-caniuse-lite@^1.0.30001669:
-  version "1.0.30001678"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001678.tgz#b930b04cd0b295136405634aa32ad540d7eeb71e"
-  integrity sha512-RR+4U/05gNtps58PEBDZcPWTgEO2MBeoPZ96aQcjmfkBWRIDfN451fW2qyDA9/+HohLLIL5GqiMwA+IB1pWarw==
+caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
+  version "1.0.30001805"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz"
+  integrity sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==
 
 chai@^5.1.2:
   version "5.3.3"


### PR DESCRIPTION
Closes barriofarmacl/whiteboard#77

## Type
- [x] New feature

## Summary
- Applies BarrioFarma brand tokens consistently to landing and login surfaces.
- Adds ESLint 9 flat configuration and resolves all lint findings.
- Refreshes Browserslist data and documents the design-token contract.

## Test plan
- [x] `yarn lint`: 0 errors, 0 warnings.
- [x] `yarn test`: 31/31 passed without React Router warnings.
- [x] `yarn build`: exit 0 without stale Browserslist warning.

## Chain context
- Chain: terrain-sales-order-and-inicio-quality
- Position: 3 of 3 (application)
- Base: `feat/pos-sales-order-terreno-frontend`
- Depends on: frontend catalog workflow PR.
- Follow-up: none.
- Review budget: 228 changed lines / 400.

```text
develop
└── backend API and permissions
    └── frontend catalog workflow
        └── [CURRENT] frontend quality bar
```

## Scope
- Includes: visual token migration, lint gate, browser data refresh, documentation.
- Excludes: backend and catalog feature implementation.