### PR TITLE
feat(permissions): Farm/Aux Batch create + SABB (whiteboard #78 PR1)

### DIFF
--- a/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
@@ -483,6 +483,39 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
         self.assertTrue(test_has_permission("Stock Reconciliation", "create", should_have=True))
         self.assertTrue(test_has_permission("Stock Reconciliation", "submit", should_have=True))
 
+    def test_farmaceutico_can_create_batch(self):
+        """Farmacéutico puede crear y escribir Batch (whiteboard #78 PR1)"""
+        from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+            setup_permissions_for_role,
+        )
+
+        frappe.set_user("Administrator")
+        setup_permissions_for_role("Farmacéutico", use_extended_strategy=True)
+        frappe.clear_cache()
+
+        frappe.set_user(self.username)
+        frappe.clear_cache()
+        self.assertTrue(test_can_access_doctype("Batch", should_access=True))
+        self.assertTrue(test_has_permission("Batch", "read", should_have=True))
+        self.assertTrue(test_has_permission("Batch", "write", should_have=True))
+        self.assertTrue(test_has_permission("Batch", "create", should_have=True))
+
+    def test_farmaceutico_can_create_serial_and_batch_bundle(self):
+        """Farmacéutico puede crear Serial and Batch Bundle (whiteboard #78 PR1)"""
+        from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+            setup_permissions_for_role,
+        )
+
+        frappe.set_user("Administrator")
+        setup_permissions_for_role("Farmacéutico", use_extended_strategy=True)
+        frappe.clear_cache()
+
+        frappe.set_user(self.username)
+        frappe.clear_cache()
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "read", should_have=True))
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "write", should_have=True))
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "create", should_have=True))
+
     def test_farmaceutico_can_read_shelf(self):
         """Farmacéutico puede leer Shelf (PR, reconciliación de inventario)"""
         frappe.set_user(self.username)
@@ -632,6 +665,39 @@ class TestAuxiliarRole(TestEpic8Story82RoleAuthorization):
         self.assertTrue(test_can_access_doctype("Stock Reconciliation", should_access=True))
         self.assertTrue(test_has_permission("Stock Reconciliation", "create", should_have=True))
         self.assertTrue(test_has_permission("Stock Reconciliation", "submit", should_have=True))
+
+    def test_auxiliar_can_create_batch(self):
+        """Auxiliar puede crear y escribir Batch (whiteboard #78 PR1)"""
+        from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+            setup_permissions_for_role,
+        )
+
+        frappe.set_user("Administrator")
+        setup_permissions_for_role("Auxiliar", use_extended_strategy=True)
+        frappe.clear_cache()
+
+        frappe.set_user(self.username)
+        frappe.clear_cache()
+        self.assertTrue(test_can_access_doctype("Batch", should_access=True))
+        self.assertTrue(test_has_permission("Batch", "read", should_have=True))
+        self.assertTrue(test_has_permission("Batch", "write", should_have=True))
+        self.assertTrue(test_has_permission("Batch", "create", should_have=True))
+
+    def test_auxiliar_can_create_serial_and_batch_bundle(self):
+        """Auxiliar puede crear Serial and Batch Bundle (whiteboard #78 PR1)"""
+        from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+            setup_permissions_for_role,
+        )
+
+        frappe.set_user("Administrator")
+        setup_permissions_for_role("Auxiliar", use_extended_strategy=True)
+        frappe.clear_cache()
+
+        frappe.set_user(self.username)
+        frappe.clear_cache()
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "read", should_have=True))
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "write", should_have=True))
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "create", should_have=True))
 
 
 class TestBodegueroRole(TestEpic8Story82RoleAuthorization):

--- a/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
+++ b/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
@@ -425,7 +425,8 @@ PERMISSIONS_MATRIX = {
         "Vendedor Terreno": ["R"],
     },
     "Serial and Batch Bundle": {
-        "Farmacéutico": ["R"],
+        # Farmacéutico: W/C para Stock Reconciliation / trazabilidad lote+serie (whiteboard #78 PR1)
+        "Farmacéutico": ["R", "W", "C"],
         "Auxiliar": ["R", "W", "C"],
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],
@@ -514,8 +515,9 @@ PERMISSIONS_MATRIX = {
         "Informática": ["R", "W", "C", "D", "S", "X"]
     },
     "Batch": {
-        "Farmacéutico": ["R"],
-        "Auxiliar": ["R"],
+        # Farm/Aux: create/write maestro de lote (whiteboard #78 PR1); Bodeguero mantiene R/W/C
+        "Farmacéutico": ["R", "W", "C"],
+        "Auxiliar": ["R", "W", "C"],
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],
         "Contabilidad": ["R"],

--- a/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions_extended.py
+++ b/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions_extended.py
@@ -240,16 +240,18 @@ SPECIFIC_DOCTYPE_PERMISSIONS = {
         "Informática": ["R", "W", "C", "D", "S", "X"]
     },
     "Batch": {
-        "Farmacéutico": ["R"],
-        "Auxiliar": ["R"],
+        # Farm/Aux: create/write maestro de lote (whiteboard #78 PR1)
+        "Farmacéutico": ["R", "W", "C"],
+        "Auxiliar": ["R", "W", "C"],
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],
         "Contabilidad": [],
         "Informática": ["R", "W", "C", "D", "S", "X"]
     },
     "Serial No": {
-        "Farmacéutico": ["R"],
-        "Auxiliar": ["R"],
+        # Alineado a Batch para trazabilidad serie en Desk (whiteboard #78 PR1)
+        "Farmacéutico": ["R", "W", "C"],
+        "Auxiliar": ["R", "W", "C"],
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],
         "Contabilidad": [],


### PR DESCRIPTION
## Summary
- Farmacéutico y Auxiliar: `Batch` pasa de `R` a `R/W/C` (matriz + extended).
- Farmacéutico: `Serial and Batch Bundle` pasa a `R/W/C` (alineado a Auxiliar/Bodeguero).
- Extended: `Serial No` Farm/Aux a `R/W/C` para trazabilidad serie en Desk.
- Tests story 8.2: 4 asserts nuevos (reaplican `setup_permissions_for_role` antes del check).

Closes part of [whiteboard #78](https://github.com/barriofarmacl/whiteboard/issues/78) (PR1 de la cadena).

## Chain context
- Tracker / issue: #78
- This PR: **PR1** permisos Batch/SABB
- Next: PR2 tests Item create Receta Retenida (Farm)

## Test plan
- [x] `bench --site barriofarma16.localhost run-tests --app barriofarma_app --module ...test_epic8_story82_role_authorization --test test_farmaceutico_can_create_batch --test test_farmaceutico_can_create_serial_and_batch_bundle --test test_auxiliar_can_create_batch --test test_auxiliar_can_create_serial_and_batch_bundle` → **4/4 OK**
- [ ] Tras merge: `setup_permissions_for_role` / migrate + re-login Natalia/Daniela; smoke create Batch en Desk
- [ ] Nota: suite completa story82 tiene fallos preexistentes (Contabilidad / buying reports), ajenos a este PR