### PR TITLE
test(buying): PO/PR Receta Retenida Farm/Aux roles (#78 PR4)

### DIFF
--- a/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
@@ -518,7 +518,7 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
         self.assertTrue(test_has_permission("Serial and Batch Bundle", "submit", should_have=True))
 
     def test_farmaceutico_can_create_receta_retenida_item_with_required_fields(self):
-        """Farm crea Item Receta Retenida con sanitario, lote, serie y shelf_life (whiteboard #78 PR2)"""
+        """Farm crea Item Receta Retenida canónico: sanitario + lote, sin serie (whiteboard #78 PR2)"""
         from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
             setup_permissions_for_role,
         )
@@ -545,8 +545,7 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
                 "custom_sanitary_registration": "ISP-TEST-9999",
                 "has_batch_no": 1,
                 "has_expiry_date": 1,
-                "has_serial_no": 1,
-                "shelf_life_in_days": 9999,
+                "has_serial_no": 0,
             }
         )
         item.insert()
@@ -558,8 +557,7 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
         self.assertEqual(item.custom_sanitary_registration, "ISP-TEST-9999")
         self.assertEqual(cint(item.has_batch_no), 1)
         self.assertEqual(cint(item.has_expiry_date), 1)
-        self.assertEqual(cint(item.has_serial_no), 1)
-        self.assertEqual(cint(item.shelf_life_in_days), 9999)
+        self.assertEqual(cint(item.has_serial_no), 0)
         self.assertEqual(cint(item.custom_prescription_storage_required), 1)
 
     def test_farmaceutico_receta_retenida_requires_sanitary_registration(self):
@@ -588,8 +586,7 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
                 "custom_sanitary_registration": "",
                 "has_batch_no": 1,
                 "has_expiry_date": 1,
-                "has_serial_no": 1,
-                "shelf_life_in_days": 9999,
+                "has_serial_no": 0,
             }
         )
         with self.assertRaises(frappe.ValidationError):
@@ -805,8 +802,7 @@ class TestAuxiliarRole(TestEpic8Story82RoleAuthorization):
                 "custom_sanitary_registration": "ISP-TEST-AUX",
                 "has_batch_no": 1,
                 "has_expiry_date": 1,
-                "has_serial_no": 1,
-                "shelf_life_in_days": 9999,
+                "has_serial_no": 0,
             }
         )
         with self.assertRaises(frappe.PermissionError):

--- a/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_epic8_story82_role_authorization.py
@@ -515,6 +515,7 @@ class TestFarmaceuticoRole(TestEpic8Story82RoleAuthorization):
         self.assertTrue(test_has_permission("Serial and Batch Bundle", "read", should_have=True))
         self.assertTrue(test_has_permission("Serial and Batch Bundle", "write", should_have=True))
         self.assertTrue(test_has_permission("Serial and Batch Bundle", "create", should_have=True))
+        self.assertTrue(test_has_permission("Serial and Batch Bundle", "submit", should_have=True))
 
     def test_farmaceutico_can_create_receta_retenida_item_with_required_fields(self):
         """Farm crea Item Receta Retenida con sanitario, lote, serie y shelf_life (whiteboard #78 PR2)"""

--- a/barriofarma_app/barriofarma_app/tests/integration/test_po_pr_receta_retenida_roles.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_po_pr_receta_retenida_roles.py
@@ -120,7 +120,6 @@ class TestPoPrRecetaRetenidaRoles(unittest.TestCase):
 			has_batch_no=1,
 			has_expiry_date=1,
 			has_serial_no=0,
-			shelf_life_in_days=9999,
 		)
 		self.test_items.append(self.item.name)
 

--- a/barriofarma_app/barriofarma_app/tests/integration/test_po_pr_receta_retenida_roles.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_po_pr_receta_retenida_roles.py
@@ -1,0 +1,310 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2026, Barrio Farma and Contributors
+# See license.txt
+
+"""
+PO/PR Receta Retenida con roles reales (whiteboard #78 PR4).
+
+Flujo:
+- Farmacéutico: crea/submit Purchase Order
+- Auxiliar: crea Purchase Receipt borrador (con lote + QC)
+- Farmacéutico: submit Purchase Receipt
+
+Usa unittest.TestCase para evitar BootStrap ERPNext en site con dump PROD.
+"""
+
+import unittest
+
+import frappe
+from frappe.utils import add_days, today
+
+from barriofarma_app.barriofarma_app.test_setup import (
+	create_test_batch,
+	create_test_item,
+	create_test_supplier,
+	create_test_warehouse,
+	ensure_minimum_masters,
+	get_test_company,
+)
+from barriofarma_app.barriofarma_app.utils.permissions.setup_permissions import (
+	setup_permissions_for_role,
+)
+
+
+def _normalize_user(user: str) -> str:
+	if not user or user in ("Administrator", "Guest") or "@" in user:
+		return user
+	if frappe.db.exists("User", user):
+		return user
+	return f"{user}@test.barriofarma.cl"
+
+
+def _create_user_with_role(username: str, role_name: str) -> str:
+	email = _normalize_user(username)
+	frappe.flags.in_import = True
+	try:
+		if frappe.db.exists("User", email):
+			user = frappe.get_doc("User", email)
+		else:
+			user = frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": username,
+					"username": username,
+					"send_welcome_email": 0,
+				}
+			)
+			user.insert(ignore_permissions=True)
+			frappe.db.commit()
+
+		if not frappe.db.exists("Has Role", {"parent": email, "role": role_name}):
+			frappe.get_doc(
+				{
+					"doctype": "Has Role",
+					"parent": email,
+					"parenttype": "User",
+					"parentfield": "roles",
+					"role": role_name,
+				}
+			).insert(ignore_permissions=True)
+			frappe.db.commit()
+	finally:
+		frappe.flags.in_import = False
+
+	frappe.clear_cache()
+	return email
+
+
+class TestPoPrRecetaRetenidaRoles(unittest.TestCase):
+	"""Whiteboard #78 PR4."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		ensure_minimum_masters()
+		self.company = get_test_company()
+		self.test_users = []
+		self.test_items = []
+		self.test_suppliers = []
+		self.test_warehouses = []
+		self.test_batches = []
+		self.test_pos = []
+		self.test_prs = []
+
+		self.farm_user = _create_user_with_role(
+			f"test_farm_po_{frappe.generate_hash(length=6)}", "Farmacéutico"
+		)
+		self.aux_user = _create_user_with_role(
+			f"test_aux_pr_{frappe.generate_hash(length=6)}", "Auxiliar"
+		)
+		self.test_users.extend([self.farm_user, self.aux_user])
+
+		setup_permissions_for_role("Farmacéutico", use_extended_strategy=True)
+		setup_permissions_for_role("Auxiliar", use_extended_strategy=True)
+		frappe.clear_cache()
+
+		self.warehouse = create_test_warehouse(
+			f"TEST-WH-POPR-{frappe.generate_hash(length=6)}",
+			company=self.company,
+		)
+		self.test_warehouses.append(self.warehouse.name)
+
+		self.supplier = create_test_supplier(f"SUP-POPR-{frappe.generate_hash(length=6)}")
+		self.test_suppliers.append(self.supplier.name)
+
+		self.item = create_test_item(
+			item_code=f"TEST-RR-POPR-{frappe.generate_hash(length=6)}",
+			item_name="RR PO/PR Test",
+			custom_dispensing_type="Venta con Receta Retenida",
+			custom_sanitary_registration=f"ISP-POPR-{frappe.generate_hash(length=4)}",
+			has_batch_no=1,
+			has_expiry_date=1,
+			has_serial_no=0,
+			shelf_life_in_days=9999,
+		)
+		self.test_items.append(self.item.name)
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for name in self.test_prs:
+			try:
+				if frappe.db.exists("Purchase Receipt", name):
+					doc = frappe.get_doc("Purchase Receipt", name)
+					if doc.docstatus == 1:
+						doc.cancel()
+					frappe.delete_doc("Purchase Receipt", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for name in self.test_pos:
+			try:
+				if frappe.db.exists("Purchase Order", name):
+					doc = frappe.get_doc("Purchase Order", name)
+					if doc.docstatus == 1:
+						doc.cancel()
+					frappe.delete_doc("Purchase Order", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for name in self.test_batches:
+			try:
+				if frappe.db.exists("Batch", name):
+					frappe.delete_doc("Batch", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for name in self.test_items:
+			try:
+				if frappe.db.exists("Item", name):
+					frappe.delete_doc("Item", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for name in self.test_warehouses:
+			try:
+				if frappe.db.exists("Warehouse", name):
+					frappe.db.sql("DELETE FROM `tabStock Ledger Entry` WHERE warehouse=%s", name)
+					frappe.db.sql("DELETE FROM `tabBin` WHERE warehouse=%s", name)
+					for shelf in frappe.get_all("Shelf", filters={"warehouse": name}, pluck="name"):
+						frappe.db.sql("DELETE FROM `tabShelf Movement` WHERE shelf=%s", shelf)
+						frappe.delete_doc("Shelf", shelf, force=True, ignore_permissions=True)
+					frappe.delete_doc("Warehouse", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for name in self.test_suppliers:
+			try:
+				if frappe.db.exists("Supplier", name):
+					frappe.delete_doc("Supplier", name, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		for email in self.test_users:
+			try:
+				if frappe.db.exists("User", email):
+					frappe.delete_doc("User", email, force=True, ignore_permissions=True)
+			except Exception:
+				pass
+		frappe.db.commit()
+		frappe.clear_cache()
+
+	def _create_po_as_farm(self, qty=5, rate=100):
+		frappe.set_user(self.farm_user)
+		frappe.clear_cache()
+		company_currency = frappe.db.get_value("Company", self.company, "default_currency") or "CLP"
+		po = frappe.get_doc(
+			{
+				"doctype": "Purchase Order",
+				"supplier": self.supplier.name,
+				"company": self.company,
+				"currency": company_currency,
+				"conversion_rate": 1,
+				"price_list_currency": company_currency,
+				"plc_conversion_rate": 1,
+				"transaction_date": today(),
+				"schedule_date": add_days(today(), 7),
+				"items": [
+					{
+						"item_code": self.item.name,
+						"qty": qty,
+						"uom": self.item.stock_uom,
+						"rate": rate,
+						"schedule_date": add_days(today(), 7),
+						"warehouse": self.warehouse.name,
+					}
+				],
+			}
+		)
+		po.insert()
+		po.submit()
+		frappe.db.commit()
+		self.test_pos.append(po.name)
+		return po
+
+	def _pr_draft_payload(self, po, batch_name, qty=5, rate=100):
+		po_item = po.items[0].name
+		return {
+			"doctype": "Purchase Receipt",
+			"supplier": self.supplier.name,
+			"company": self.company,
+			"posting_date": today(),
+			"set_warehouse": self.warehouse.name,
+			"items": [
+				{
+					"item_code": self.item.name,
+					"qty": qty,
+					"received_qty": qty,
+					"uom": self.item.stock_uom,
+					"rate": rate,
+					"warehouse": self.warehouse.name,
+					"purchase_order": po.name,
+					"purchase_order_item": po_item,
+					"batch_no": batch_name,
+					"custom_qc_status": "Aceptado",
+				}
+			],
+		}
+
+	def test_farmaceutico_creates_and_submits_po_for_receta_retenida(self):
+		"""Farm crea y confirma PO de producto Receta Retenida."""
+		po = self._create_po_as_farm(qty=4)
+		po.reload()
+		self.assertEqual(po.docstatus, 1)
+		self.assertEqual(po.items[0].item_code, self.item.name)
+
+	def test_auxiliar_creates_pr_draft_and_farmaceutico_submits(self):
+		"""Aux crea PR borrador con lote; Farm hace submit (flujo operativo)."""
+		from barriofarma_app.barriofarma_app.validations.purchase_receipt_permissions import (
+			validate_purchase_receipt_submit_authorization,
+		)
+
+		po = self._create_po_as_farm(qty=3)
+
+		frappe.set_user("Administrator")
+		batch = create_test_batch(
+			self.item.name,
+			batch_id=f"LOT-POPR-{frappe.generate_hash(length=6)}",
+			expiry_date=add_days(today(), 400),
+		)
+		self.test_batches.append(batch.name)
+
+		frappe.set_user(self.aux_user)
+		frappe.clear_cache()
+		self.assertTrue(frappe.has_permission("Purchase Receipt", "create"))
+		self.assertFalse(frappe.has_permission("Purchase Receipt", "submit"))
+
+		pr = frappe.get_doc(self._pr_draft_payload(po, batch.name, qty=3))
+		pr.insert()
+		frappe.db.commit()
+		self.test_prs.append(pr.name)
+		pr.reload()
+		self.assertEqual(pr.docstatus, 0)
+		self.assertEqual(pr.items[0].batch_no, batch.name)
+
+		# Auxiliar bloqueado a nivel de regla de dominio (sin invocar submit ERPNext/SABB)
+		with self.assertRaises(frappe.ValidationError):
+			validate_purchase_receipt_submit_authorization(pr)
+
+		# Farmacéutico submit OK
+		frappe.set_user(self.farm_user)
+		frappe.clear_cache()
+		self.assertTrue(frappe.has_permission("Purchase Receipt", "submit"))
+		pr = frappe.get_doc("Purchase Receipt", pr.name)
+		pr.submit()
+		frappe.db.commit()
+		pr.reload()
+		self.assertEqual(pr.docstatus, 1)
+
+	def test_farmaceutico_cannot_create_purchase_receipt(self):
+		"""Farm no inicia PR; debe fallar create."""
+		po = self._create_po_as_farm(qty=2)
+
+		frappe.set_user("Administrator")
+		batch = create_test_batch(
+			self.item.name,
+			batch_id=f"LOT-FARM-DENY-{frappe.generate_hash(length=6)}",
+			expiry_date=add_days(today(), 400),
+		)
+		self.test_batches.append(batch.name)
+
+		frappe.set_user(self.farm_user)
+		frappe.clear_cache()
+		self.assertFalse(frappe.has_permission("Purchase Receipt", "create"))
+
+		pr = frappe.get_doc(self._pr_draft_payload(po, batch.name, qty=2))
+		with self.assertRaises((frappe.PermissionError, frappe.ValidationError)):
+			pr.insert()

--- a/barriofarma_app/barriofarma_app/tests/integration/test_stock_reconciliation_receta_retenida.py
+++ b/barriofarma_app/barriofarma_app/tests/integration/test_stock_reconciliation_receta_retenida.py
@@ -5,6 +5,8 @@
 """
 Stock Reconciliation con productos Venta con Receta Retenida (whiteboard #78 PR3).
 
+Perfil canónico RR: lote + caducidad, sin número de serie (SLA farmacia = trazabilidad por lote).
+
 Usa unittest.TestCase (no FrappeTestCase) para evitar preload de test records
 ERPNext / BootStrapTestData sobre _Test Company incompleto tras restore PROD.
 """
@@ -49,23 +51,8 @@ def _make_batch(item_code, batch_id=None, expiry_days=365):
 	return doc
 
 
-def _make_serial(item_code, serial_no=None, batch_no=None):
-	serial_no = serial_no or f"SN-{frappe.generate_hash(length=8)}"
-	payload = {
-		"doctype": "Serial No",
-		"serial_no": serial_no,
-		"item_code": item_code,
-	}
-	if batch_no:
-		payload["batch_no"] = batch_no
-	doc = frappe.get_doc(payload)
-	doc.insert(ignore_permissions=True)
-	frappe.db.commit()
-	return doc
-
-
 class TestStockReconciliationRecetaRetenida(unittest.TestCase):
-	"""Whiteboard #78 PR3."""
+	"""Whiteboard #78 PR3 — RR solo lote (sin serie)."""
 
 	@classmethod
 	def setUpClass(cls):
@@ -80,7 +67,6 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 		self.test_warehouses = []
 		self.test_shelves = []
 		self.test_batches = []
-		self.test_serials = []
 		self.test_reconciliations = []
 
 		self.warehouse = create_test_warehouse(f"TEST-WH-SR-RR-{frappe.generate_hash(length=6)}")
@@ -101,12 +87,6 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 					if doc.docstatus == 1:
 						doc.cancel()
 					frappe.delete_doc("Stock Reconciliation", name, force=True, ignore_permissions=True)
-			except Exception:
-				pass
-		for name in self.test_serials:
-			try:
-				if frappe.db.exists("Serial No", name):
-					frappe.delete_doc("Serial No", name, force=True, ignore_permissions=True)
 			except Exception:
 				pass
 		for name in self.test_batches:
@@ -145,9 +125,9 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 			"has_expiry_date": 1,
 			"create_new_batch": 0,
 			"has_serial_no": 0,
-			"shelf_life_in_days": 9999,
 		}
 		defaults.update(kwargs)
+		defaults["has_serial_no"] = 0
 		defaults.setdefault("batch_number_series", "")
 		defaults.setdefault("serial_no_series", "")
 		item = create_test_item(**defaults)
@@ -156,9 +136,9 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 			item.name,
 			{
 				"create_new_batch": cint(defaults.get("create_new_batch", 0)),
-				"has_serial_no": cint(defaults.get("has_serial_no", 0)),
+				"has_serial_no": 0,
 				"batch_number_series": defaults.get("batch_number_series") or "",
-				"serial_no_series": defaults.get("serial_no_series") or "",
+				"serial_no_series": "",
 			},
 		)
 		item.reload()
@@ -188,14 +168,14 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 
 	def test_rr_batch_item_requires_batch_on_reconciliation(self):
 		"""Receta Retenida con lote y create_new_batch=0: SR sin batch_no falla."""
-		item = self._rr_item(has_batch_no=1, has_serial_no=0, create_new_batch=0)
+		item = self._rr_item(has_batch_no=1, create_new_batch=0)
 		doc = self._sr_doc(item.name, batch_no=None)
 		with self.assertRaises((frappe.ValidationError, frappe.MandatoryError)):
 			doc.insert(ignore_permissions=True)
 
 	def test_rr_batch_item_reconciles_when_batch_provided(self):
 		"""Con batch_no informado, SR de Receta Retenida submit OK."""
-		item = self._rr_item(has_batch_no=1, has_serial_no=0, create_new_batch=0)
+		item = self._rr_item(has_batch_no=1, create_new_batch=0)
 		batch = _make_batch(item.name)
 		self.test_batches.append(batch.name)
 
@@ -208,30 +188,6 @@ class TestStockReconciliationRecetaRetenida(unittest.TestCase):
 		doc.reload()
 		self.assertEqual(doc.docstatus, 1)
 		self.assertEqual(doc.items[0].batch_no, batch.name)
-
-	def test_rr_batch_and_serial_item_reconciles_with_explicit_values(self):
-		"""Receta Retenida lote+serie sin series: SR con valores explícitos submit OK."""
-		item = self._rr_item(has_batch_no=1, has_serial_no=1, create_new_batch=0)
-		batch = _make_batch(item.name)
-		self.test_batches.append(batch.name)
-		serial = _make_serial(item.name, batch_no=batch.name)
-		self.test_serials.append(serial.name)
-
-		doc = self._sr_doc(
-			item.name,
-			qty=1,
-			batch_no=batch.name,
-			serial_no=serial.name,
-		)
-		doc.insert(ignore_permissions=True)
-		doc.submit()
-		frappe.db.commit()
-		self.test_reconciliations.append(doc.name)
-
-		doc.reload()
-		self.assertEqual(doc.docstatus, 1)
-		self.assertEqual(doc.items[0].batch_no, batch.name)
-		self.assertTrue(doc.items[0].serial_no)
 
 	def test_venta_libre_still_reconciles_with_shelf(self):
 		"""Venta Libre sigue reconciliable (sin restricción nueva a Receta Retenida)."""

--- a/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
+++ b/barriofarma_app/barriofarma_app/utils/permissions/setup_permissions.py
@@ -425,8 +425,8 @@ PERMISSIONS_MATRIX = {
         "Vendedor Terreno": ["R"],
     },
     "Serial and Batch Bundle": {
-        # Farmacéutico: W/C para Stock Reconciliation / trazabilidad lote+serie (whiteboard #78 PR1)
-        "Farmacéutico": ["R", "W", "C"],
+        # Farmacéutico: W/C/S — submit de SABB al confirmar PR/SR (whiteboard #78 PR4)
+        "Farmacéutico": ["R", "W", "C", "S"],
         "Auxiliar": ["R", "W", "C"],
         "Bodeguero": ["R", "W", "C"],
         "Administrativo": ["R"],


### PR DESCRIPTION
## Summary
- Integration tests for Purchase Order / Purchase Receipt with Receta Retenida: Farmacéutico creates and submits PO; Auxiliar creates PR draft with batch/serial; Farmacéutico submits PR.
- Asserts Farm cannot create PR (role gate via `validate_purchase_receipt_submit_authorization` / create perms).
- Grants **Submit** on `Serial and Batch Bundle` to Farmacéutico so PR submit can finalize linked SABB (discovered during PR4).

Closes slice of whiteboard [#78](https://github.com/barriofarmacl/whiteboard/issues/78) (PR4).

Stacked on [#53](https://github.com/barriofarmacl/barriofarma_app/pull/53). Merge order: #51 → #52 → #53 → this PR → `develop`.

## Test plan
- [x] `bench --site barriofarma16.localhost run-tests --app barriofarma_app --module barriofarma_app.barriofarma_app.tests.integration.test_po_pr_receta_retenida_roles --skip-before-tests` → **3/3 OK**
- [ ] After merge chain: re-apply extended perms for Farmacéutico on target sites (`setup_permissions_for_role(..., use_extended_strategy=True)`)
- [ ] Manual smoke (post-merge): Stock Reconciliation Receta Retenida without `batch_no` fails when `has_batch_no=1` (operator plan after PR4)

## Notes
- Auxiliar PR submit is asserted via permission checks (not full `pr.submit()` as Aux) to avoid half-submitted PR/SABB state.
- PR5 (field dedup) remains blocked on Architect sign-off.