### PR TITLE
fix(item): Psico/VL dispensing guard follow-up (#78 PR5)

### DIFF
--- a/barriofarma_app/barriofarma_app/overrides/item.py
+++ b/barriofarma_app/barriofarma_app/overrides/item.py
@@ -179,6 +179,17 @@ class Item(ERPNextItem):
             return
         
         if dispensing_type == "Venta Libre":
+            control_level = self.get("custom_control_level")
+            if control_level in ("Psicotrópico", "Estupefaciente"):
+                frappe.throw(
+                    _(
+                        "Los medicamentos {0} requieren Tipo de Dispensación "
+                        "'Venta con Receta Retenida'. 'Venta Libre' no es compatible "
+                        "con este nivel de control."
+                    ).format(frappe.bold(control_level)),
+                    title=_("Invariante de Dispensación No Cumplida"),
+                )
+
             # Venta Libre: no requiere lote ni almacenamiento de receta
             if self.get("has_batch_no"):
                 # No lanzamos error, solo ajustamos automáticamente para cumplir invariante

--- a/barriofarma_app/barriofarma_app/tests/unit/test_item_validation_overrides_mocks.py
+++ b/barriofarma_app/barriofarma_app/tests/unit/test_item_validation_overrides_mocks.py
@@ -817,8 +817,9 @@ class TestValidateMethodIntegration(unittest.TestCase):
         mock_throw.assert_not_called()
 
     @patch('frappe.throw')
-    def test_psicotropico_venta_libre_falla_tras_sync_dispensing(self, mock_throw):
-        """Psicotrópico + Venta Libre: sync limpia retention y control_level falla"""
+    def test_psicotropico_venta_libre_falla_en_dispensing(self, mock_throw):
+        """Psicotrópico + Venta Libre: error claro en dispensing (no limpiar batch silencioso)"""
+        mock_throw.side_effect = Exception("stop")
         item = MockItem(
             custom_control_level="Psicotrópico",
             custom_dispensing_type="Venta Libre",
@@ -828,16 +829,12 @@ class TestValidateMethodIntegration(unittest.TestCase):
             custom_prescription_storage_required=0,
         )
 
-        self.Item.validate_dispensing_type_invariants(item)
-        self.assertEqual(item.get("custom_requires_prescription_retention"), 0)
+        with self.assertRaises(Exception):
+            self.Item.validate_dispensing_type_invariants(item)
 
-        self.Item.validate_control_level_invariants(item)
-        self.assertTrue(mock_throw.called)
-        messages = [str(c.args[0]) for c in mock_throw.call_args_list]
-        self.assertTrue(
-            any("receta retenida" in m for m in messages),
-            msg=f"Expected retention invariant error, got: {messages}",
-        )
+        mock_throw.assert_called_once()
+        self.assertIn("Venta con Receta Retenida", mock_throw.call_args[0][0])
+        self.assertEqual(item.get("has_batch_no"), 1)
 
 
 class TestEdgeCases(unittest.TestCase):


### PR DESCRIPTION
## Summary
Follow-up to #56 (PR5): commit `ee7b248` was pushed to `feat/item-dispensing-retention-sync` **after** #56 merged, so `develop` lacked the Psico/VL guard.

**Fix:** reject `Psicotrópico`/`Estupefaciente` + `Venta Libre` in `validate_dispensing_type_invariants` **before** silently clearing `has_batch_no`. Prevents misleading *"has_batch_no debe estar marcado"* when the user had the checkbox on.

Part of whiteboard [#78](https://github.com/barriofarmacl/whiteboard/issues/78).

## Test plan
- [x] `test_psicotropico_venta_libre_falla_en_dispensing` OK
- [x] Manual smoke BF-2302: change to RR + Psico saves correctly

## Scope
- 2 files only; cherry-pick of `ee7b248`